### PR TITLE
Added cp command tip to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Firmware for the 2018 University of Waterloo Mars Rover. Will contain:
     - load code by going to Target->Program and browse for .bin file
 	
 	For Mac
-    - Drag and Drop .bin file into NODE_F091RC disk (Will show up like other usb devices after connecting)
+    - Drag and Drop .bin file into NODE_F091RC disk (Will show up like other usb devices after connecting) or run `cp build/blinky_out.bin /Volumes/NODE_F091RC/`


### PR DESCRIPTION
Added a code snippet to the readme to show how to copy the `.bin` to the board without leaving Terminal.